### PR TITLE
Add setup script for one-command bootstrap

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -30,6 +30,8 @@ done
 
 # Expected edge apikey — must match openems-edge/config.d/Controller/Api/Backend/*.config
 EDGE_APIKEY="E3SZ5xdJ2FJ0jPMtajdm"
+# Odoo password — must match openems-backend/config.d/Metadata/Odoo.config (odooPassword)
+ODOO_PASSWORD="Icui4cyou"
 
 # ── Step 1: Build images ─────────────────────────────────────────────
 if [ "$SKIP_BUILD" = false ]; then
@@ -72,6 +74,24 @@ else
     --stop-after-init
 
   log "Odoo database created and OpenEMS module installed."
+
+  # Set Odoo passwords to match backend Metadata/Odoo.config.
+  # The CLI creates admin with password 'admin', but the backend expects
+  # odooPassword for XML-RPC calls (used for UI user authentication).
+  log "Setting Odoo passwords to match backend config..."
+  docker compose up -d odoo16
+  sleep 5
+  docker compose exec -T odoo16 python3 -c "
+import xmlrpc.client
+url = 'http://localhost:8069'
+db = 'openems'
+uid = xmlrpc.client.ServerProxy(f'{url}/xmlrpc/2/common').authenticate(db, 'admin', 'admin', {})
+models = xmlrpc.client.ServerProxy(f'{url}/xmlrpc/2/object')
+models.execute_kw(db, uid, 'admin', 'res.users', 'write', [[uid], {'password': '$ODOO_PASSWORD'}])
+models.execute_kw(db, uid, '$ODOO_PASSWORD', 'res.users', 'write', [[1], {'password': '$ODOO_PASSWORD'}])
+print('Odoo passwords updated')
+"
+  docker compose stop odoo16
 fi
 
 # ── Step 4: Verify edge device registration ───────────────────────────
@@ -98,6 +118,12 @@ fi
 # ── Step 5: Start the full stack ──────────────────────────────────────
 log "Starting all services..."
 docker compose up -d
+
+# The edge doesn't auto-reconnect quickly if it started before the backend
+# was ready. Restart it to ensure a clean connection.
+log "Restarting edge to ensure backend connection..."
+sleep 5
+docker compose restart openems-edge
 
 # ── Step 6: Verify the stack (retry loop) ─────────────────────────────
 log "Waiting for services to start..."
@@ -154,5 +180,5 @@ log "  Felix Console:   http://localhost:8080"
 log "  InfluxDB:        http://localhost:8086"
 log ""
 log "Default credentials:"
-log "  OpenEMS UI:  admin / admin"
-log "  Odoo:        admin / (set during DB creation, master pw: openemspassword)"
+log "  OpenEMS UI:  admin / Icui4cyou"
+log "  Odoo:        admin / Icui4cyou  (master pw: openemspassword)"

--- a/setup.sh
+++ b/setup.sh
@@ -99,54 +99,51 @@ fi
 log "Starting all services..."
 docker compose up -d
 
-# ── Step 6: Wait for services to stabilize ────────────────────────────
-log "Waiting for services to start (20s)..."
-sleep 20
+# ── Step 6: Verify the stack (retry loop) ─────────────────────────────
+log "Waiting for services to start..."
 
-# ── Step 7: Verify the stack ──────────────────────────────────────────
+check_logs() {
+  local service="$1"
+  local pattern="$2"
+  local logs
+  logs=$(docker compose logs "$service" 2>/dev/null)
+  echo "$logs" | grep -q "$pattern"
+}
+
+CHECKS_PASSED=false
+for attempt in $(seq 1 12); do
+  sleep 10
+  PASS=true
+
+  check_logs openems-backend "Caching Edges.*finished" || PASS=false
+  check_logs openems-backend "InfluxDB"                || PASS=false
+  check_logs openems-edge    "Scheduler"               || PASS=false
+  check_logs openems-backend "Edge.Websocket"          || PASS=false
+
+  if [ "$PASS" = true ]; then
+    CHECKS_PASSED=true
+    break
+  fi
+  log "  Waiting... (${attempt}/12)"
+done
+
 log ""
 log "=== Verification ==="
-
-PASS=true
-
-# Backend → Postgres
-if docker compose logs openems-backend 2>&1 | grep -q "Caching Edges.*finished"; then
+if [ "$CHECKS_PASSED" = true ]; then
   log "  Backend -> Postgres:  OK"
-else
-  warn "  Backend -> Postgres:  NOT CONFIRMED (may need more time)"
-  PASS=false
-fi
-
-# Backend → InfluxDB
-if docker compose logs openems-backend 2>&1 | grep -q "InfluxDB"; then
   log "  Backend -> InfluxDB:  OK"
-else
-  warn "  Backend -> InfluxDB:  NOT CONFIRMED"
-  PASS=false
-fi
-
-# Edge → Scheduler
-if docker compose logs openems-edge 2>&1 | grep -q "Scheduler"; then
   log "  Edge scheduler:       OK"
-else
-  warn "  Edge scheduler:       NOT CONFIRMED"
-  PASS=false
-fi
-
-# Edge → Backend
-if docker compose logs openems-backend 2>&1 | grep -q "Edge.Websocket"; then
   log "  Edge -> Backend:      OK"
-else
-  warn "  Edge -> Backend:      NOT CONFIRMED (may need more time)"
-  PASS=false
-fi
-
-log ""
-if [ "$PASS" = true ]; then
+  log ""
   log "All checks passed!"
 else
-  warn "Some checks did not pass yet. Services may still be starting."
-  warn "Re-run verification: docker compose logs --tail=50 openems-backend openems-edge"
+  check_logs openems-backend "Caching Edges.*finished" && log "  Backend -> Postgres:  OK" || warn "  Backend -> Postgres:  FAILED"
+  check_logs openems-backend "InfluxDB"                && log "  Backend -> InfluxDB:  OK" || warn "  Backend -> InfluxDB:  FAILED"
+  check_logs openems-edge    "Scheduler"               && log "  Edge scheduler:       OK" || warn "  Edge scheduler:       FAILED"
+  check_logs openems-backend "Edge.Websocket"          && log "  Edge -> Backend:      OK" || warn "  Edge -> Backend:      FAILED"
+  log ""
+  warn "Some checks failed after 2 minutes."
+  warn "Check logs: docker compose logs --tail=50 openems-backend openems-edge"
 fi
 
 log ""

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# setup.sh — One-command bootstrap for the OpenEMS Docker stack.
+# Safe to run on a fresh clone or after destroying all containers/images/volumes.
+# Idempotent: skips steps that are already done.
+#
+# Usage:
+#   ./setup.sh          # full setup (build + init + verify)
+#   ./setup.sh --skip-build   # skip docker compose build (images already exist)
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+log()  { echo -e "${GREEN}[setup]${NC} $*"; }
+warn() { echo -e "${YELLOW}[setup]${NC} $*"; }
+err()  { echo -e "${RED}[setup]${NC} $*" >&2; }
+
+SKIP_BUILD=false
+for arg in "$@"; do
+  case "$arg" in
+    --skip-build) SKIP_BUILD=true ;;
+    *) err "Unknown argument: $arg"; exit 1 ;;
+  esac
+done
+
+# Expected edge apikey — must match openems-edge/config.d/Controller/Api/Backend/*.config
+EDGE_APIKEY="E3SZ5xdJ2FJ0jPMtajdm"
+
+# ── Step 1: Build images ─────────────────────────────────────────────
+if [ "$SKIP_BUILD" = false ]; then
+  log "Building Docker images..."
+  docker compose build
+else
+  log "Skipping build (--skip-build)"
+fi
+
+# ── Step 2: Start infrastructure (db + influxdb) ─────────────────────
+log "Starting database services..."
+docker compose up -d db influxdb
+
+log "Waiting for Postgres to be ready..."
+for i in $(seq 1 30); do
+  if docker compose exec -T db pg_isready -U odoo >/dev/null 2>&1; then
+    break
+  fi
+  if [ "$i" -eq 30 ]; then
+    err "Postgres did not become ready in 60 seconds."
+    exit 1
+  fi
+  sleep 2
+done
+log "Postgres is ready."
+
+# ── Step 3: Initialize Odoo database (if needed) ─────────────────────
+DB_EXISTS=$(docker compose exec -T db psql -U odoo -tAc \
+  "SELECT 1 FROM pg_database WHERE datname='openems'" 2>/dev/null || echo "")
+
+if [ "$DB_EXISTS" = "1" ]; then
+  log "Odoo database 'openems' already exists — skipping initialization."
+else
+  log "Creating Odoo database and installing OpenEMS module..."
+  log "(This installs Odoo + CRM + Stock + OpenEMS. Takes 2-4 minutes.)"
+
+  docker compose run --rm odoo16 odoo \
+    -d openems \
+    -i openems \
+    --stop-after-init
+
+  log "Odoo database created and OpenEMS module installed."
+fi
+
+# ── Step 4: Verify edge device registration ───────────────────────────
+EDGE_KEY=$(docker compose exec -T db psql -U odoo -d openems -tAc \
+  "SELECT apikey FROM openems_device WHERE name='edge0'" 2>/dev/null | tr -d '[:space:]' || echo "")
+
+if [ -z "$EDGE_KEY" ]; then
+  warn "Edge device 'edge0' not found in database."
+  warn "Demo data may not have loaded. Creating edge device..."
+  docker compose exec -T db psql -U odoo -d openems -c \
+    "INSERT INTO openems_device (name, apikey, comment, create_uid, create_date, write_uid, write_date)
+     VALUES ('edge0', '$EDGE_APIKEY', 'OpenEMS Edge #0', 1, NOW(), 1, NOW());"
+  log "Edge device created."
+elif [ "$EDGE_KEY" != "$EDGE_APIKEY" ]; then
+  warn "Edge apikey mismatch: DB='$EDGE_KEY', expected='$EDGE_APIKEY'"
+  warn "Updating database to match edge config..."
+  docker compose exec -T db psql -U odoo -d openems -c \
+    "UPDATE openems_device SET apikey='$EDGE_APIKEY' WHERE name='edge0';"
+  log "Edge apikey updated."
+else
+  log "Edge device 'edge0' registered with correct apikey."
+fi
+
+# ── Step 5: Start the full stack ──────────────────────────────────────
+log "Starting all services..."
+docker compose up -d
+
+# ── Step 6: Wait for services to stabilize ────────────────────────────
+log "Waiting for services to start (20s)..."
+sleep 20
+
+# ── Step 7: Verify the stack ──────────────────────────────────────────
+log ""
+log "=== Verification ==="
+
+PASS=true
+
+# Backend → Postgres
+if docker compose logs openems-backend 2>&1 | grep -q "Caching Edges.*finished"; then
+  log "  Backend -> Postgres:  OK"
+else
+  warn "  Backend -> Postgres:  NOT CONFIRMED (may need more time)"
+  PASS=false
+fi
+
+# Backend → InfluxDB
+if docker compose logs openems-backend 2>&1 | grep -q "InfluxDB"; then
+  log "  Backend -> InfluxDB:  OK"
+else
+  warn "  Backend -> InfluxDB:  NOT CONFIRMED"
+  PASS=false
+fi
+
+# Edge → Scheduler
+if docker compose logs openems-edge 2>&1 | grep -q "Scheduler"; then
+  log "  Edge scheduler:       OK"
+else
+  warn "  Edge scheduler:       NOT CONFIRMED"
+  PASS=false
+fi
+
+# Edge → Backend
+if docker compose logs openems-backend 2>&1 | grep -q "Edge.Websocket"; then
+  log "  Edge -> Backend:      OK"
+else
+  warn "  Edge -> Backend:      NOT CONFIRMED (may need more time)"
+  PASS=false
+fi
+
+log ""
+if [ "$PASS" = true ]; then
+  log "All checks passed!"
+else
+  warn "Some checks did not pass yet. Services may still be starting."
+  warn "Re-run verification: docker compose logs --tail=50 openems-backend openems-edge"
+fi
+
+log ""
+log "Stack is ready:"
+log "  OpenEMS UI:      http://localhost:4200"
+log "  Odoo:            http://localhost:10016"
+log "  Felix Console:   http://localhost:8080"
+log "  InfluxDB:        http://localhost:8086"
+log ""
+log "Default credentials:"
+log "  OpenEMS UI:  admin / admin"
+log "  Odoo:        admin / (set during DB creation, master pw: openemspassword)"


### PR DESCRIPTION
## Summary
- Add `setup.sh` that automates full environment bootstrap from scratch
- Handles: image build, Odoo DB creation + password sync, OpenEMS module install, edge device verification, service healthchecks
- Idempotent — safe to re-run on an existing setup (skips completed steps)
- Tested with 4x full destroy + restore cycles

Closes #58

## Usage

```bash
# Full setup from scratch (build + init + verify)
./setup.sh

# Skip docker compose build (images already exist)
./setup.sh --skip-build
```

### What it does step by step

| Step | What happens | Time |
|------|-------------|------|
| 1. Build | `docker compose build` — builds all 6 images | ~5s (cached) |
| 2. Start infra | Starts `db` + `influxdb` first, waits for Postgres ready | ~10s |
| 3. Init Odoo | Creates `openems` database, installs OpenEMS module, loads demo data (edge device) | ~2-4 min |
| 3b. Sync passwords | Sets Odoo UID 1 + admin passwords to match backend config (`Icui4cyou`) | ~5s |
| 4. Verify edge | Checks `openems_device` table for `edge0` with correct apikey. Creates or fixes if needed | ~1s |
| 5. Start stack | `docker compose up -d` + restart edge for clean backend connection | ~20s |
| 6. Verify | Polls backend/edge logs every 10s for up to 2 min until all 4 checks pass | ~50s |

**Total: ~4-7 minutes** (mostly Odoo module installation)

### Default credentials after setup

| Service | Username | Password |
|---------|----------|----------|
| OpenEMS UI (`localhost:4200`) | `admin` | `Icui4cyou` |
| Odoo (`localhost:10016`) | `admin` | `Icui4cyou` |
| Odoo DB manager | — | `openemspassword` |

## Troubleshooting

### Odoo init takes longer than expected
The `odoo -d openems -i openems --stop-after-init` step installs Odoo + all dependencies (CRM, Stock, Mail, etc.). On first run with no cache this can take 3-5 minutes. This is normal.

### "Authentication failed" in OpenEMS UI
The backend authenticates UI users via Odoo XML-RPC. The setup script syncs passwords automatically, but if you changed the Odoo admin password manually, it must match `odooPassword` in `openems-backend/config.d/Metadata/Odoo.config`. Fix:
```bash
# Check current backend config
grep odooPassword openems-backend/config.d/Metadata/Odoo.config

# Reset Odoo admin password via Postgres
docker compose exec db psql -U odoo -d openems -c \
  "UPDATE res_users SET password='' WHERE login='admin';"
# Then log into Odoo at localhost:10016 to set a new password
```

### Edge shows "offline" in the UI
The edge may have started before the backend was ready. Restart it:
```bash
docker compose restart openems-edge
```

### Verification checks fail
The script polls for 2 minutes. If checks still fail:
```bash
# Check if containers are running
docker compose ps

# Check backend logs for errors
docker compose logs --tail=100 openems-backend

# Check edge logs
docker compose logs --tail=100 openems-edge
```

### "Edge device not found" warning
This means Odoo's demo data didn't load the edge device. The script auto-creates it via SQL insert. If you see this warning but the script continues, it's handled.

### Edge authentication failed (COMMON_AUTHENTICATION_FAILED)
The edge config apikey must match the `openems_device.apikey` in Postgres. Verify:
```bash
# Check what's in the database
docker compose exec db psql -U odoo -d openems \
  -c "SELECT name, apikey FROM openems_device;"

# Check what's in the edge config
grep apikey openems-edge/config.d/Controller/Api/Backend/*.config
```
Both values must match. The setup script handles this automatically.

### Ports already in use
```bash
lsof -i :4200   # UI
lsof -i :8080   # Felix console
lsof -i :8086   # InfluxDB
lsof -i :10016  # Odoo
```

### Starting over completely
```bash
docker compose down -v    # removes containers + named volumes
rm -rf postgresql/        # removes Postgres bind mount data
./setup.sh                # rebuild from scratch
```

## Issues found and fixed during testing

| Issue | Root cause | Fix |
|-------|-----------|-----|
| Verification always failed | `pipefail` + `grep -q` causes SIGPIPE on `docker compose logs` pipe | Capture logs to variable first, then grep |
| UI login "auth failed" | Fresh Odoo DB has password `admin`, backend expects `Icui4cyou` | Script sets Odoo passwords via XML-RPC after init |
| Edge shows offline | Edge starts before backend, doesn't auto-reconnect | Script restarts edge after full stack start |

🤖 Generated with [Claude Code](https://claude.com/claude-code)