### PR TITLE
Add Lambda VPC proxy for MBE-to-OpenEMS B2B access

### DIFF
--- a/iac/dev/.gitignore
+++ b/iac/dev/.gitignore
@@ -1,0 +1,5 @@
+terraform.tfvars
+.terraform/
+.terraform.lock.hcl
+*.tfstate
+*.tfstate.backup

--- a/iac/dev/.gitignore
+++ b/iac/dev/.gitignore
@@ -3,3 +3,4 @@ terraform.tfvars
 .terraform.lock.hcl
 *.tfstate
 *.tfstate.backup
+lambda/proxy.zip

--- a/iac/dev/README.md
+++ b/iac/dev/README.md
@@ -1,0 +1,89 @@
+# Dev Environment (AWS)
+
+Single-EC2 deployment of the OpenEMS stack for development. Isolated from the production `iac/` configuration (separate VPC, separate Terraform state key).
+
+## What it provisions
+
+- VPC `10.100.0.0/16` with a single public subnet
+- EC2 `t3.large` (Ubuntu 22.04), runs full `docker-compose` stack via `setup.sh`
+- Security group scoped to `allowed_ips` (no `0.0.0.0/0`)
+- IAM role for SSM Session Manager (no SSH key required)
+
+Ports exposed to `allowed_ips`:
+- `4200` — OpenEMS UI
+- `8082` — OpenEMS Backend B2B REST (for MBE)
+- `10016` — Odoo
+- `8086` — InfluxDB HTTP (debugging)
+
+## Prerequisites
+
+- AWS credentials for account `470298448112` with permissions: `AmazonEC2FullAccess`, `IAMFullAccess`, `AmazonSSMFullAccess`
+- Terraform >= 1.3
+- `aws-cli` v2 (for SSM Session Manager)
+- [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed locally
+
+## First-time setup
+
+```bash
+cd iac/dev
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars — add your IPs to allowed_ips
+terraform init
+terraform plan
+terraform apply
+```
+
+After `apply`, outputs include the public IP and connection URLs. The stack takes **~10 minutes** to bootstrap on first boot (Docker image builds).
+
+## Watching the bootstrap
+
+```bash
+# Copy from terraform output
+$(terraform output -raw bootstrap_log_tail)
+```
+
+Bootstrap is complete when you see `All checks passed!` in the log.
+
+## Adding / removing IPs
+
+Edit `terraform.tfvars`, add or remove entries in `allowed_ips`, then:
+
+```bash
+terraform apply
+```
+
+Only the security group rules change — no instance disruption.
+
+## Accessing the instance
+
+```bash
+# Interactive shell (SSM, no SSH)
+$(terraform output -raw ssm_connect_command)
+```
+
+## Destroying
+
+```bash
+terraform destroy
+```
+
+Tears down everything except the shared Terraform state (which lives in the `openems-deployment-tf-state-file` S3 bucket).
+
+## Troubleshooting
+
+**Bootstrap stuck / failed?**
+```bash
+aws ssm start-session --target <instance-id>
+sudo tail -100 /var/log/openems-bootstrap.log
+cd /opt/docker-openems && sudo docker compose ps
+```
+
+**Need to re-bootstrap?**
+The `user_data` script only runs on first boot. To re-run, destroy and recreate:
+```bash
+terraform destroy -target=aws_instance.openems
+terraform apply
+```
+
+**Stack consuming too much RAM?**
+Bump `instance_type` to `t3.xlarge` in `terraform.tfvars`, then `terraform apply` — this will replace the instance.

--- a/iac/dev/backend.tf
+++ b/iac/dev/backend.tf
@@ -8,13 +8,12 @@ terraform {
     }
   }
 
-  # Reuses the existing state bucket used by iac/ — different key for isolation.
-  # The bucket and lock table already exist in the AWS account.
+  # State bucket and lock table provisioned by admin in the EIOT dev account.
   backend "s3" {
-    bucket         = "openems-deployment-tf-state-file"
+    bucket         = "docker-openems-feature-dev-iac"
     key            = "iac/dev/terraform.tfstate"
     region         = "us-east-1"
-    dynamodb_table = "terraform-state-lock-openems-deployment"
+    dynamodb_table = "docker-openems-feature-dev-iac-state-lock"
     encrypt        = true
   }
 }

--- a/iac/dev/backend.tf
+++ b/iac/dev/backend.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  # Reuses the existing state bucket used by iac/ — different key for isolation.
+  # The bucket and lock table already exist in the AWS account.
+  backend "s3" {
+    bucket         = "openems-deployment-tf-state-file"
+    key            = "iac/dev/terraform.tfstate"
+    region         = "us-east-1"
+    dynamodb_table = "terraform-state-lock-openems-deployment"
+    encrypt        = true
+  }
+}

--- a/iac/dev/ec2.tf
+++ b/iac/dev/ec2.tf
@@ -1,0 +1,51 @@
+# Ubuntu 22.04 LTS (Canonical official AMI)
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_instance" "openems" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.public.id
+  vpc_security_group_ids = [aws_security_group.openems.id]
+  iam_instance_profile   = aws_iam_instance_profile.ec2_ssm.name
+
+  # Enforce IMDSv2
+  metadata_options {
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+  }
+
+  root_block_device {
+    volume_size           = var.root_volume_size_gb
+    volume_type           = "gp3"
+    delete_on_termination = true
+    encrypted             = true
+  }
+
+  user_data = templatefile("${path.module}/user-data.sh.tpl", {
+    git_branch = var.git_branch
+    edge_count = var.edge_count
+  })
+
+  # user_data changes should NOT replace the instance — it only runs on first boot.
+  # If you need to re-bootstrap, destroy and recreate the instance explicitly.
+  lifecycle {
+    ignore_changes = [user_data, ami]
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-stack"
+  }
+}

--- a/iac/dev/iam.tf
+++ b/iac/dev/iam.tf
@@ -1,0 +1,25 @@
+# EC2 instance role for SSM Session Manager — no SSH key needed.
+resource "aws_iam_role" "ec2_ssm" {
+  name = "${var.project_name}-${var.environment}-ec2-ssm-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm_managed" {
+  role       = aws_iam_role.ec2_ssm.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ec2_ssm" {
+  name = "${var.project_name}-${var.environment}-ec2-ssm-profile"
+  role = aws_iam_role.ec2_ssm.name
+}

--- a/iac/dev/lambda.tf
+++ b/iac/dev/lambda.tf
@@ -1,0 +1,154 @@
+# ---------------------------------------------------------------------------
+# Lambda VPC proxy — forwards MBE requests to OpenEMS B2B on private IP
+# ---------------------------------------------------------------------------
+
+# Package the function code into a zip
+data "archive_file" "lambda_proxy" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/index.mjs"
+  output_path = "${path.module}/lambda/proxy.zip"
+}
+
+# ---------------------------------------------------------------------------
+# IAM execution role
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "lambda_proxy" {
+  name = "${var.project_name}-${var.environment}-lambda-proxy-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-lambda-proxy-role"
+  }
+}
+
+# AWSLambdaVPCAccessExecutionRole covers: VPC ENI management + CloudWatch Logs
+resource "aws_iam_role_policy_attachment" "lambda_vpc_access" {
+  role       = aws_iam_role.lambda_proxy.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+}
+
+# ---------------------------------------------------------------------------
+# Security group for Lambda
+# ---------------------------------------------------------------------------
+
+resource "aws_security_group" "lambda_proxy" {
+  name        = "${var.project_name}-${var.environment}-lambda-proxy-sg"
+  description = "Lambda proxy: egress to OpenEMS B2B port only"
+  vpc_id      = aws_vpc.main.id
+
+  egress {
+    description              = "OpenEMS B2B REST"
+    from_port                = 8082
+    to_port                  = 8082
+    protocol                 = "tcp"
+    source_security_group_id = aws_security_group.openems.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-lambda-proxy-sg"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Lambda function
+# ---------------------------------------------------------------------------
+
+resource "aws_lambda_function" "proxy" {
+  function_name = "${var.project_name}-${var.environment}-b2b-proxy"
+  role          = aws_iam_role.lambda_proxy.arn
+  runtime       = "nodejs20.x"
+  handler       = "index.handler"
+  filename      = data.archive_file.lambda_proxy.output_path
+  source_code_hash = data.archive_file.lambda_proxy.output_base64sha256
+
+  memory_size = 128
+  timeout     = 30
+
+  vpc_config {
+    subnet_ids         = [aws_subnet.public.id]
+    security_group_ids = [aws_security_group.lambda_proxy.id]
+  }
+
+  environment {
+    variables = {
+      OPENEMS_HOST       = aws_instance.openems.private_ip
+      OPENEMS_B2B_CREDS  = var.openems_b2b_creds
+    }
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.lambda_vpc_access,
+    aws_cloudwatch_log_group.lambda_proxy,
+  ]
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-b2b-proxy"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Function URL (HTTPS + IAM SigV4 auth)
+# ---------------------------------------------------------------------------
+
+resource "aws_lambda_function_url" "proxy" {
+  function_name      = aws_lambda_function.proxy.function_name
+  authorization_type = "AWS_IAM"
+  invoke_mode        = "BUFFERED"
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch log group
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "lambda_proxy" {
+  name              = "/aws/lambda/${var.project_name}-${var.environment}-b2b-proxy"
+  retention_in_days = 14
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-b2b-proxy-logs"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# IAM user for Vercel (MBE invoker)
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_user" "mbe_invoker" {
+  name = "${var.project_name}-${var.environment}-mbe-invoker"
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-mbe-invoker"
+  }
+}
+
+resource "aws_iam_access_key" "mbe_invoker" {
+  user = aws_iam_user.mbe_invoker.name
+}
+
+resource "aws_iam_user_policy" "mbe_invoker_invoke" {
+  name = "${var.project_name}-${var.environment}-mbe-invoker-policy"
+  user = aws_iam_user.mbe_invoker.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = "lambda:InvokeFunctionUrl"
+      Resource = aws_lambda_function.proxy.arn
+      Condition = {
+        StringEquals = {
+          "lambda:FunctionUrlAuthType" = "AWS_IAM"
+        }
+      }
+    }]
+  })
+}

--- a/iac/dev/lambda.tf
+++ b/iac/dev/lambda.tf
@@ -46,11 +46,11 @@ resource "aws_security_group" "lambda_proxy" {
   vpc_id      = aws_vpc.main.id
 
   egress {
-    description              = "OpenEMS B2B REST"
-    from_port                = 8082
-    to_port                  = 8082
-    protocol                 = "tcp"
-    source_security_group_id = aws_security_group.openems.id
+    description     = "OpenEMS B2B REST"
+    from_port       = 8082
+    to_port         = 8082
+    protocol        = "tcp"
+    security_groups = [aws_security_group.openems.id]
   }
 
   tags = {

--- a/iac/dev/lambda/index.mjs
+++ b/iac/dev/lambda/index.mjs
@@ -1,0 +1,34 @@
+export async function handler(event) {
+  const body = event.isBase64Encoded
+    ? Buffer.from(event.body, 'base64').toString('utf-8')
+    : event.body;
+
+  try {
+    const response = await fetch(
+      `http://${process.env.OPENEMS_HOST}:8082/jsonrpc`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Basic ${process.env.OPENEMS_B2B_CREDS}`
+        },
+        body
+      }
+    );
+    return {
+      statusCode: response.status,
+      headers: { 'Content-Type': 'application/json' },
+      isBase64Encoded: false,
+      body: await response.text()
+    };
+  } catch (err) {
+    return {
+      statusCode: 502,
+      headers: { 'Content-Type': 'application/json' },
+      isBase64Encoded: false,
+      body: JSON.stringify({
+        error: { message: 'Backend unreachable', code: 'PROXY_BACKEND_UNREACHABLE' }
+      })
+    };
+  }
+}

--- a/iac/dev/outputs.tf
+++ b/iac/dev/outputs.tf
@@ -13,9 +13,25 @@ output "ui_url" {
   value       = "http://${aws_instance.openems.public_ip}:4200"
 }
 
-output "b2b_url" {
-  description = "OpenEMS B2B REST endpoint (for MBE)"
+output "b2b_url_direct" {
+  description = "OpenEMS B2B REST endpoint — direct public IP access (for debugging; keep allowed_ips locked down)"
   value       = "http://${aws_instance.openems.public_ip}:8082"
+}
+
+output "b2b_url_lambda" {
+  description = "OpenEMS B2B REST endpoint via Lambda VPC proxy (HTTPS + IAM SigV4)"
+  value       = aws_lambda_function_url.proxy.function_url
+}
+
+output "lambda_invoker_access_key_id" {
+  description = "Access key ID for the MBE invoker IAM user (set as OPENEMS_AWS_ACCESS_KEY_ID in Vercel)"
+  value       = aws_iam_access_key.mbe_invoker.id
+}
+
+output "lambda_invoker_secret_key" {
+  description = "Secret access key for the MBE invoker IAM user (set as OPENEMS_AWS_SECRET_ACCESS_KEY in Vercel)"
+  value       = aws_iam_access_key.mbe_invoker.secret
+  sensitive   = true
 }
 
 output "odoo_url" {

--- a/iac/dev/outputs.tf
+++ b/iac/dev/outputs.tf
@@ -1,0 +1,34 @@
+output "instance_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.openems.id
+}
+
+output "public_ip" {
+  description = "Public IP of the EC2 instance"
+  value       = aws_instance.openems.public_ip
+}
+
+output "ui_url" {
+  description = "OpenEMS UI URL"
+  value       = "http://${aws_instance.openems.public_ip}:4200"
+}
+
+output "b2b_url" {
+  description = "OpenEMS B2B REST endpoint (for MBE)"
+  value       = "http://${aws_instance.openems.public_ip}:8082"
+}
+
+output "odoo_url" {
+  description = "Odoo admin URL"
+  value       = "http://${aws_instance.openems.public_ip}:10016"
+}
+
+output "ssm_connect_command" {
+  description = "Connect to the instance via SSM Session Manager"
+  value       = "aws ssm start-session --target ${aws_instance.openems.id} --region ${var.region}"
+}
+
+output "bootstrap_log_tail" {
+  description = "Tail the bootstrap log via SSM"
+  value       = "aws ssm start-session --target ${aws_instance.openems.id} --region ${var.region} --document-name AWS-StartInteractiveCommand --parameters command='sudo tail -f /var/log/openems-bootstrap.log'"
+}

--- a/iac/dev/provider.tf
+++ b/iac/dev/provider.tf
@@ -4,7 +4,7 @@ provider "aws" {
   default_tags {
     tags = {
       Project     = "openems"
-      Environment = "dev"
+      Environment = "aidev"
       ManagedBy   = "terraform"
       Component   = "openems-stack"
     }

--- a/iac/dev/provider.tf
+++ b/iac/dev/provider.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = {
+      Project     = "openems"
+      Environment = "dev"
+      ManagedBy   = "terraform"
+      Component   = "openems-stack"
+    }
+  }
+}

--- a/iac/dev/security.tf
+++ b/iac/dev/security.tf
@@ -1,0 +1,55 @@
+resource "aws_security_group" "openems" {
+  name        = "${var.project_name}-${var.environment}-stack-sg"
+  description = "Scoped access to dev OpenEMS stack (UI, B2B, Odoo)"
+  vpc_id      = aws_vpc.main.id
+
+  # OpenEMS UI (nginx)
+  ingress {
+    description = "OpenEMS UI"
+    from_port   = 4200
+    to_port     = 4200
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_ips
+  }
+
+  # OpenEMS Backend B2B REST (used by MBE)
+  ingress {
+    description = "OpenEMS Backend B2B REST"
+    from_port   = 8082
+    to_port     = 8082
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_ips
+  }
+
+  # Odoo web UI
+  ingress {
+    description = "Odoo"
+    from_port   = 10016
+    to_port     = 10016
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_ips
+  }
+
+  # InfluxDB HTTP (optional — for debugging)
+  ingress {
+    description = "InfluxDB HTTP"
+    from_port   = 8086
+    to_port     = 8086
+    protocol    = "tcp"
+    cidr_blocks = var.allowed_ips
+  }
+
+  # NOTE: no SSH ingress — use SSM Session Manager for shell access.
+
+  egress {
+    description = "All outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-stack-sg"
+  }
+}

--- a/iac/dev/security.tf
+++ b/iac/dev/security.tf
@@ -53,3 +53,14 @@ resource "aws_security_group" "openems" {
     Name = "${var.project_name}-${var.environment}-stack-sg"
   }
 }
+
+# Allow Lambda proxy to reach the OpenEMS B2B port via SG-to-SG reference
+resource "aws_security_group_rule" "openems_from_lambda_b2b" {
+  description              = "OpenEMS B2B REST from Lambda proxy"
+  type                     = "ingress"
+  from_port                = 8082
+  to_port                  = 8082
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.lambda_proxy.id
+  security_group_id        = aws_security_group.openems.id
+}

--- a/iac/dev/terraform.tfvars.example
+++ b/iac/dev/terraform.tfvars.example
@@ -1,0 +1,12 @@
+# Copy to terraform.tfvars and fill in your values.
+# terraform.tfvars is gitignored — do not commit personal IPs.
+
+allowed_ips = [
+  # "203.0.113.42/32",   # Alejandro (home) — replace with your actual IP
+  # "198.51.100.17/32",  # Aidan — replace with actual IP
+]
+
+# Override defaults if needed:
+# instance_type       = "t3.xlarge"   # if stack runs hot
+# edge_count          = 3
+# git_branch          = "local-deployment"

--- a/iac/dev/terraform.tfvars.example
+++ b/iac/dev/terraform.tfvars.example
@@ -6,6 +6,10 @@ allowed_ips = [
   # "198.51.100.17/32",  # Aidan — replace with actual IP
 ]
 
+# B2B credentials for the Lambda proxy (base64-encoded "user:password")
+# Generate with: echo -n 'admin:your-password' | base64
+openems_b2b_creds = "REPLACE_ME"
+
 # Override defaults if needed:
 # instance_type       = "t3.xlarge"   # if stack runs hot
 # edge_count          = 3

--- a/iac/dev/user-data.sh.tpl
+++ b/iac/dev/user-data.sh.tpl
@@ -1,0 +1,47 @@
+#!/bin/bash
+# OpenEMS dev stack bootstrap — runs on first boot as root via cloud-init.
+# Logs land in /var/log/cloud-init-output.log (and /var/log/openems-bootstrap.log).
+
+set -euo pipefail
+exec > >(tee -a /var/log/openems-bootstrap.log) 2>&1
+
+echo "[bootstrap] Starting at $(date)"
+
+# ── Install prerequisites ────────────────────────────────────────────
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y ca-certificates curl gnupg git jq
+
+# Docker (official repo)
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" > /etc/apt/sources.list.d/docker.list
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+systemctl enable --now docker
+
+# Allow ubuntu user to run docker without sudo
+usermod -aG docker ubuntu || true
+
+# ── Clone docker-openems repo ────────────────────────────────────────
+INSTALL_DIR=/opt/docker-openems
+if [ ! -d "$INSTALL_DIR" ]; then
+  git clone --branch "${git_branch}" https://github.com/energy-iot/docker-openems.git "$INSTALL_DIR"
+fi
+cd "$INSTALL_DIR"
+
+# ── Run setup.sh ─────────────────────────────────────────────────────
+# setup.sh is idempotent; safe to re-run.
+# Build happens here — first run takes ~10 min on t3.large.
+chmod +x setup.sh
+./setup.sh --edges "${edge_count}" || {
+  echo "[bootstrap] setup.sh failed — check docker logs"
+  exit 1
+}
+
+echo "[bootstrap] Completed at $(date)"
+echo "[bootstrap] UI:    http://$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4):4200"
+echo "[bootstrap] B2B:   http://$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4):8082"
+echo "[bootstrap] Odoo:  http://$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4):10016"

--- a/iac/dev/variables.tf
+++ b/iac/dev/variables.tf
@@ -51,3 +51,9 @@ variable "edge_count" {
   description = "Number of simulated edges to bootstrap"
   default     = 2
 }
+
+variable "openems_b2b_creds" {
+  type        = string
+  description = "Base64-encoded Basic auth credentials for the OpenEMS B2B REST API. Generate with: echo -n 'user:password' | base64"
+  sensitive   = true
+}

--- a/iac/dev/variables.tf
+++ b/iac/dev/variables.tf
@@ -1,0 +1,53 @@
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "project_name" {
+  type    = string
+  default = "openems"
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "VPC CIDR — chosen to not collide with existing iac/ VPC (10.0.0.0/16)"
+  default     = "10.100.0.0/16"
+}
+
+variable "public_subnet_cidr" {
+  type    = string
+  default = "10.100.0.0/24"
+}
+
+variable "allowed_ips" {
+  type        = list(string)
+  description = "List of CIDR blocks allowed to reach the dev stack (UI, B2B, Odoo). Use /32 for single IPs."
+}
+
+variable "instance_type" {
+  type        = string
+  description = "EC2 instance type for the OpenEMS stack host"
+  default     = "t3.large"
+}
+
+variable "root_volume_size_gb" {
+  type    = number
+  default = 40
+}
+
+variable "git_branch" {
+  type        = string
+  description = "docker-openems branch to check out on the instance"
+  default     = "local-deployment"
+}
+
+variable "edge_count" {
+  type        = number
+  description = "Number of simulated edges to bootstrap"
+  default     = 2
+}

--- a/iac/dev/vpc.tf
+++ b/iac/dev/vpc.tf
@@ -1,0 +1,50 @@
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-vpc"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-igw"
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidr
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-public"
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-public-rt"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}


### PR DESCRIPTION
## Summary

Adds a Lambda VPC proxy to `iac/dev/` that allows MBE (on Vercel) to securely access the OpenEMS B2B REST API without exposing the backend to the public internet. This is **Option 3** from the architecture discussion in PR #70.

- Lambda sits inside the VPC, forwards JSON-RPC requests to the backend via private IP
- Function URL with IAM auth (SigV4) — stronger than API keys, logged in CloudTrail
- Stateless passthrough (~15 lines) — no business logic, no dependencies, deploy once
- Cost: ~$0/mo (Lambda free tier covers MBE's ~100-500 req/month)

Closes #73

## Changes

**New files:**
- `iac/dev/lambda/index.mjs` — Node.js 20 proxy function (handles errors, base64 encoding)
- `iac/dev/lambda.tf` — Lambda function, IAM roles, security group, Function URL, CloudWatch log group, Vercel invoker IAM user + access key

**Modified files:**
- `iac/dev/security.tf` — Added EC2 SG ingress rule from Lambda SG on port 8082 (SG-to-SG)
- `iac/dev/outputs.tf` — Renamed `b2b_url` → `b2b_url_direct`, added `b2b_url_lambda`, IAM key outputs
- `iac/dev/variables.tf` — Added `openems_b2b_creds` (sensitive)
- `iac/dev/terraform.tfvars.example` — Documented new variable
- `iac/dev/.gitignore` — Added `lambda/proxy.zip`

## Prerequisites

Before `terraform apply`:
- Aidan needs to add `AWSLambda_FullAccess` (or scoped `lambda:*`) to the `claude-code-dev` IAM user
- `openems_b2b_creds` must be set in `terraform.tfvars` (base64-encoded `user:password`)

## Test plan

- [ ] `terraform plan` shows Lambda + IAM + SG resources to create (no changes to existing EC2/VPC)
- [ ] `terraform apply` succeeds
- [ ] Lambda appears in AWS Console, attached to the dev VPC
- [ ] Manual test with `awscurl`: POST to the Function URL with SigV4 → valid JSON-RPC response from backend
- [ ] CloudWatch logs show the invocation
- [ ] EC2 SG shows inbound rule from Lambda SG on port 8082
- [ ] `terraform destroy` cleans up all Lambda resources + log group

🤖 Generated with [Claude Code](https://claude.com/claude-code)