### PR TITLE
Fix dev deployment: addons mount path + setup.sh build step

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       #- /etc/timezone:/etc/timezone:ro
       #- /etc/localtime:/etc/localtime:ro
       # - ./entrypoint.sh:/entrypoint.sh   # if you want to install additional Python packages, uncomment this line!
-      - ./addons:/mnt/extra-addons
+      - ./odoo/addons:/mnt/extra-addons
       - ./etc:/etc/odoo
     restart: always 
 

--- a/setup.sh
+++ b/setup.sh
@@ -203,9 +203,16 @@ done
 generate_compose_override
 
 # ── Step 1: Build images ─────────────────────────────────────────────
+# Use -f docker-compose.yml explicitly: the override generated above
+# disables `openems-edge` (profile "disabled") so it can be replaced
+# with N `openems-edge-0..N-1` services that reference the image by
+# tag without a build. Without -f, `docker compose build` honors the
+# override and skips building openems-edge entirely, so when the
+# edge-N services try to start they fail with "pull access denied
+# for openems-edge" (the image doesn't exist locally).
 if [ "$SKIP_BUILD" = false ]; then
   log "Building Docker images..."
-  docker compose build
+  docker compose -f docker-compose.yml build
 else
   log "Skipping build (--skip-build)"
 fi


### PR DESCRIPTION
## Summary

Two small fixes to unblock fresh-clone deployments of the `local-deployment` stack (both discovered during 2026-04-21 AWS dev env validation). The stack works on existing developer laptops but fails on any clean environment (new team member laptop, fresh EC2, CI runner).

Two labeled commits, each self-contained:

**1. `b18172c` — fix(compose): addons volume mount path**

Commit `6de6851` (Jan 2026, "move addon folder") moved Odoo addons from repo-root `addons/` to `odoo/addons/`. `odoo/Dockerfile` was incidentally correct (build context is `./odoo/`, so its `COPY addons` resolves to `odoo/addons/`). But `docker-compose.yml:94` kept the old path and now overlays the image's baked-in modules with an empty host directory. Result: Odoo starts without the `openems` module, and `setup.sh` fails with "relation `openems_device` does not exist" when creating edge0.

Fix: `./addons:/mnt/extra-addons` → `./odoo/addons:/mnt/extra-addons`.

**2. `9b6289e` — fix(setup): build images from base compose only**

`setup.sh --edges N` generates a `docker-compose.override.yml` that disables the base `openems-edge` service (`profiles: ["disabled"]`) and replaces it with N numbered `openems-edge-0..N-1` services that reference the image by tag without a `build:` directive. When `docker compose build` runs afterward, it merges both files, honors the disabled profile, and skips building openems-edge entirely. When `up` later tries to start the numbered services it fails with `pull access denied for openems-edge`.

Fix: `docker compose -f docker-compose.yml build` — ignores the override at build time, still uses it at `up` time.

## Test plan

- [ ] `git clean -fdx` (or clone fresh) on an existing laptop
- [ ] `./setup.sh --edges 2`
- [ ] Expect "All checks passed!" without manual intervention
- [ ] UI at http://localhost:4200 loads, edge0/edge1 online with simulation data
- [ ] (Done by Alejandro on AWS EC2) apply on a fresh EC2 instance bootstrap

## Context

These are part of a bundle of "AWS dev env unblocker" fixes. The Terraform-side fixes (B2B port 8082→8075, IMDSv2 token fetch) were pushed to #75 in separate labeled commits — see #75 for that side of the work. Those live in `iac/dev/` and target `main`; these live at repo root and target `local-deployment`. Different branches, so they had to split PRs.

@aidan-barnes-axm — no AWS/infra changes here, purely docker-compose + setup.sh. Review at your convenience.